### PR TITLE
unit test for flat-mesh parcels output

### DIFF
--- a/tests/test_parcels.py
+++ b/tests/test_parcels.py
@@ -1,0 +1,18 @@
+import trajan as _
+import xarray as xr
+import matplotlib.pyplot as plt
+import pytest
+
+
+@pytest.mark.parametrize('animate', [False, True])
+def test_parcels_flatmesh(animate, plot):
+    ds = xr.open_dataset('tests/test_data/parcels.zarr', engine='zarr')
+    ds = ds.traj.set_crs(None)
+    print(ds)
+    if animate:
+        ds.traj.animate()
+    else:
+        ds.traj.plot()
+
+    if plot:
+        plt.show()


### PR DESCRIPTION
Thanks for implementing a `ds.traj.animate()` functionality in #46! However, I fear it's not yet working for the Parcels output in your `tests/test_data/parcels.zarr` file. I've added a breaking example file here.

The problem seems to be the default(?) 1-hour interval for the animation? The error I'm getting is
```python
Traceback (most recent call last):
  File "/Users/erik/miniconda3/envs/py3_parcels/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 3803, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas/_libs/index.pyx", line 138, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 165, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 2263, in pandas._libs.hashtable.Int64HashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 2273, in pandas._libs.hashtable.Int64HashTable.get_item
KeyError: 0

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/erik/miniconda3/envs/py3_parcels/lib/python3.10/site-packages/xarray/core/indexes.py", line 468, in sel
    indexer = self.index.get_loc(label_value)
  File "/Users/erik/miniconda3/envs/py3_parcels/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 3805, in get_loc
    raise KeyError(key) from err
KeyError: 0

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/erik/Codes/trajan/tests/test_parcels.py", line 19, in <module>
    test_parcels_flatmesh(True, True)
  File "/Users/erik/Codes/trajan/tests/test_parcels.py", line 12, in test_parcels_flatmesh
    ds.traj.animate()
  File "/Users/erik/Codes/trajan/trajan/animation/__init__.py", line 27, in __call__
    return self.animate(*args, **kwargs)
  File "/Users/erik/Codes/trajan/trajan/animation/__init__.py", line 34, in animate
    ds = self.ds.traj.gridtime(times='1H')
  File "/Users/erik/Codes/trajan/trajan/traj2d.py", line 66, in gridtime
    da.loc[{'trajectory': t}] = f(times.to_numpy().astype(np.float64))
  File "/Users/erik/miniconda3/envs/py3_parcels/lib/python3.10/site-packages/xarray/core/dataarray.py", line 216, in __setitem__
    dim_indexers = map_index_queries(self.data_array, key).dim_indexers
  File "/Users/erik/miniconda3/envs/py3_parcels/lib/python3.10/site-packages/xarray/core/indexing.py", line 183, in map_index_queries
    results.append(index.sel(labels, **options))  # type: ignore[call-arg]
  File "/Users/erik/miniconda3/envs/py3_parcels/lib/python3.10/site-packages/xarray/core/indexes.py", line 470, in sel
    raise KeyError(
KeyError: "not all values found in index 'trajectory'. Try setting the `method` keyword argument (example: method='nearest')."
```