### PR TITLE
Fix conda install instruction

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ Installation
 
 .. code-block:: console
 
-   $ conda -c conda-forge install trajan
+   $ conda install -c conda-forge trajan
 
 
 or


### PR DESCRIPTION
Trying to install following the instructions I got:

```
~> eval "$(/home/jrmet/miniconda3/bin/conda shell.bash hook)" && conda activate myenv
(myenv) ~> conda -c conda-forge install trajan

CommandNotFoundError: No command 'conda conda-forge'.
```

doing this instead works:

```
(myenv) ~> conda install -c conda-forge trajan
Retrieving notices: ...working... done
[... working fine ...]
```