### PR TITLE
Feat/allow omb start time

### DIFF
--- a/examples/example_omb_csv_reader.py
+++ b/examples/example_omb_csv_reader.py
@@ -6,6 +6,7 @@ Reading an OMB Rock7 CSV file into trajan
 from pathlib import Path
 from trajan.readers.omb import read_omb_csv
 import coloredlogs
+import datetime
 
 # adjust the level of information printed
 # coloredlogs.install(level='error')
@@ -35,9 +36,17 @@ print(xr_result)
 
 #%%
 # example 2: custom size of wave packets; for users who have changed the firmware to transmit
+# and using a set start time: ignore messages before it
 # more or less spectrum bins
 
 path_to_test_data = Path.cwd().parent / "tests" / "test_data" / "csv" / "omb2.csv"
+
+# the start times dict specification
+dict_instruments_params = {
+    "RockBLOCK 206702": {
+        "start_time": datetime.datetime(2022, 10, 29, 0, 0, 0),
+    }
+}
 
 # the properties description of the modified binary wave packets
 dict_wave_packet_params = {
@@ -47,7 +56,7 @@ dict_wave_packet_params = {
 }
 
 # specify the binary wave packet specification corresponding to the modified firmware
-xr_result = read_omb_csv(path_to_test_data, modified_wave_packet_properties=dict_wave_packet_params)
+xr_result = read_omb_csv(path_to_test_data, dict_instruments_params=dict_instruments_params, modified_wave_packet_properties=dict_wave_packet_params)
 
 # look at the dataset obtained
 print(xr_result)

--- a/trajan/readers/omb.py
+++ b/trajan/readers/omb.py
@@ -149,7 +149,7 @@ def read_omb_csv(path_in: Path,
         # a GNSS packet may contain several data entries; split it here for simplicity
         if crrt_kind == "G":
             for crrt_fix in crrt_list_packets:
-                if crrt_fix.datetime_fix > crrt_start_time:
+                if crrt_start_time is None or crrt_fix.datetime_fix > crrt_start_time:
                     crrt_parsed = ParsedIridiumMessage(
                         device_from=crrt_data.Device,
                         kind=crrt_kind,
@@ -168,7 +168,7 @@ def read_omb_csv(path_in: Path,
                 frequencies_set = True
                 frequencies = crrt_list_packets[0].list_frequencies
 
-            if crrt_list_packets[0].datetime_fix > crrt_start_time:
+            if crrt_start_time is None or crrt_list_packets[0].datetime_fix > crrt_start_time:
                 crrt_parsed = ParsedIridiumMessage(
                     device_from=crrt_data.Device,
                     kind=crrt_kind,

--- a/trajan/readers/omb.py
+++ b/trajan/readers/omb.py
@@ -4,6 +4,7 @@ import logging
 import pandas as pd
 from dataclasses import dataclass
 import numpy as np
+import datetime
 
 from .omb_decoder import decode_message
 from typing import Union
@@ -61,6 +62,7 @@ def append_dict_with_entry(dict_in: dict, parsed_entry: ParsedIridiumMessage):
 
 
 def read_omb_csv(path_in: Path,
+                 dict_instruments_params: dict = None,
                  modified_wave_packet_properties: dict = None) -> xr.Dataset:
     logger.debug("read path to pandas")
 
@@ -118,6 +120,15 @@ def read_omb_csv(path_in: Path,
             )
             continue
 
+        # only use data that are after the start time for the current buoy
+        crrt_start_time = None
+
+        if dict_instruments_params is not None:
+            crrt_instrument = getattr(crrt_data, "Device")
+            if crrt_instrument in dict_instruments_params:
+                if "start_time" in dict_instruments_params[crrt_instrument]:
+                    crrt_start_time = dict_instruments_params[crrt_instrument]["start_time"]
+
         # we should only have valid dataframes at this point; attempt to decode
         # hard to catch exceptions in a fine grain way, so cath all, but only on the decoding itself
         # however, in practice, all messages should be decodable, and if not this is a serious issue; don t be silent
@@ -138,14 +149,18 @@ def read_omb_csv(path_in: Path,
         # a GNSS packet may contain several data entries; split it here for simplicity
         if crrt_kind == "G":
             for crrt_fix in crrt_list_packets:
-                crrt_parsed = ParsedIridiumMessage(
-                    device_from=crrt_data.Device,
-                    kind=crrt_kind,
-                    meta=crrt_meta,
-                    data=crrt_fix,
-                )
+                if crrt_fix.datetime_fix > crrt_start_time:
+                    crrt_parsed = ParsedIridiumMessage(
+                        device_from=crrt_data.Device,
+                        kind=crrt_kind,
+                        meta=crrt_meta,
+                        data=crrt_fix,
+                    )
 
-                append_dict_with_entry(dict_entries, crrt_parsed)
+                    append_dict_with_entry(dict_entries, crrt_parsed)
+
+                else:
+                    logger.info(f"buoy {crrt_instrument}: ignore fix {crrt_fix}, since before {crrt_start_time}")
 
         # other packets contain a single entry: add as is
         else:
@@ -153,14 +168,18 @@ def read_omb_csv(path_in: Path,
                 frequencies_set = True
                 frequencies = crrt_list_packets[0].list_frequencies
 
-            crrt_parsed = ParsedIridiumMessage(
-                device_from=crrt_data.Device,
-                kind=crrt_kind,
-                meta=crrt_meta,
-                data=crrt_list_packets[0],
-            )
+            if crrt_list_packets[0].datetime_fix > crrt_start_time:
+                crrt_parsed = ParsedIridiumMessage(
+                    device_from=crrt_data.Device,
+                    kind=crrt_kind,
+                    meta=crrt_meta,
+                    data=crrt_list_packets[0],
+                )
 
-            append_dict_with_entry(dict_entries, crrt_parsed)
+                append_dict_with_entry(dict_entries, crrt_parsed)
+
+            else:
+                logger.info(f"buoy {crrt_instrument}: ignore spectrum with timestamp {crrt_list_packets[0].datetime_fix}, since before {crrt_start_time}")
 
     if number_valid_entries == 0:
         logger.warning(


### PR DESCRIPTION
Make it possible to consider only messages received after a given time point. Very convenient since instruments are usually switched on a bit before deployment.

Update both the omb reader and the omb example. Example works fine, as well as a larger use case I am working on, with the local installation on my machine.