### PR TITLE
Add the __version__ attribute

### DIFF
--- a/trajan/__init__.py
+++ b/trajan/__init__.py
@@ -1,6 +1,9 @@
 """
 Trajan API
 """
+
+import importlib.metadata
+
 import collections
 import numpy as np
 import xarray as xr
@@ -13,6 +16,9 @@ from . import skill as _
 from . import readers as _
 
 logger = logging.getLogger(__name__)
+
+__version__ = importlib.metadata.version("trajan")
+
 
 def read_csv(f, **kwargs):
     """


### PR DESCRIPTION
This is just a very minor attribute update.

Before:

```python
>>> trajan.__version__
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    trajan.__version__
AttributeError: module 'trajan' has no attribute '__version__'

```

Now:

```python
>>> trajan.__version__
'0.7.0'
```

I often end up poking stuff like ```PKG.__version__```, I thought it may be nice here too :) .