### PR TITLE
Add fastplot plot function

### DIFF
--- a/tests/test_fastplot.py
+++ b/tests/test_fastplot.py
@@ -1,0 +1,21 @@
+import xarray as xr
+import trajan as _
+import matplotlib.pyplot as plt
+
+
+def test_fastplot(test_data, plot):
+    ds = xr.open_dataset(test_data / 'xr_spotter_bulk_test_data.nc')
+
+    # let us check that the conversion worked well, and that all main functionalities are working
+
+    # plotting without centering
+    plt.figure()
+    ds.traj.plot.fastplot()
+
+    # plotting with centering
+    plt.figure()
+    ds.traj.plot.fastplot(center_lon_circmean=True)
+
+    if plot:
+        plt.show()
+

--- a/trajan/plot/__init__.py
+++ b/trajan/plot/__init__.py
@@ -3,6 +3,7 @@ import matplotlib.pyplot as plt
 import cartopy.crs as ccrs
 import numpy as np
 import xarray as xr
+import scipy as sp
 
 from .land import add_land
 
@@ -134,6 +135,46 @@ class Plot:
 
     def __call__(self, *args, **kwargs):
         return self.lines(*args, **kwargs)
+
+    def fastplot(self, center_lon_circmean=False):
+        """
+        Do a fast plot of the data. This uses PlateCarree, no transform on the plotting,
+        and circmean to determine the optimal central longitude to use.
+
+        This only plots markers, not lines, to avoid wrapping lines on global datasets.
+
+        Args:
+
+            center_lon_circmean: bool, whether to use the circmean of the longitude
+                of the data to set the central_longitude in PlateCarree (if True), or
+                the default (0) if False.
+        """
+
+        if self.__cartesian__:
+            x = self.ds.traj.tx.values.T
+            y = self.ds.traj.ty.values.T
+        else:
+            x = self.ds.traj.tlon.values.T
+            y = self.ds.traj.tlat.values.T
+
+        if center_lon_circmean:
+            all_y = x.flatten()
+            mid_y = 180.0 / np.pi * sp.stats.circmean(all_y * np.pi / 180.0, nan_policy="omit")
+        else:
+            mid_y = 0.0
+
+        ax = plt.axes(projection=ccrs.PlateCarree(central_longitude=mid_y))
+        ax.coastlines()
+
+        if len(x.shape) == 2:
+            for crrt_buoy_idx in range(x.shape[1]):
+                plt.plot(x[:, crrt_buoy_idx], y[:, crrt_buoy_idx], linestyle="none", marker=".", markersize=1)
+        elif len(x.shape) == 1:
+            plt.plot(x, y, linestyle="none", marker=".", markersize=1)
+        else:
+            raise ValueError(f"the position data to plot has shape {x.shape = }; unclear how to plot this!")
+
+        gl = ax.gridlines(transform=ccrs.PlateCarree(central_longitude=mid_y), draw_labels=True)
 
     def lines(self, *args, **kwargs):
         """


### PR DESCRIPTION
Using trajan I regularly feel like I wait quite a bit when plotting, and I miss a "fastplot" function, that does "simple and basic but fast" plotting without too many options to tune. The default plotting functions are very nice, but they can be slow especially with large datasets, when land is in the view, etc.

The idea with "fastplot" is to provide a rudimentary plot that is drawn very fast and provides few options - for advanced plotting, the other already existing functions should be used.

A couple of points:

- it uses `PlateCarree` for the `projection`, and no `transform`, as I have found when working with large dataset that the `transform` arg makes the plotting very slow
- it also optionally sets the `central_longitude` using `scipy.stats.circmean`; this way, if there is a dataset that is "heavily centered" around a given region of the world, this is what will be used by `PlateCarree`
- it does not plot lines, only markers - this way, we avoid "crossing lines" on global dataset

I agree that it has quite some overlap with other existing functions, but I think that for large datasets, it is convenient to have a "quick and efficient" plot function to try in just one call in early data exploration. If you do not want to merge this e.g. because it is "redundant ad hoc functionality for a specific use case", maybe we should think about how the existing functions could get a flag or similar to optionally get this kind of behavior? :)