### PR TITLE
Update the contiguous ragged example to match latest class

### DIFF
--- a/examples/example_contiguous_ragged.py
+++ b/examples/example_contiguous_ragged.py
@@ -29,9 +29,17 @@ plt.show()
 
 # %%
 
-# this is because, under the hood, trajan is generating a Traj2D non ragged dataset that follows the usual trajan conventions
+# it is possible to get a 2d-array dataset version using trajan:
 
-xr_data.traj.ds
+# compare:
+print(f"{xr_data.traj.ds = }")
+
+# with:
+xr_data_as_2darray = xr_data.traj.to_2d()
+print(f"{xr_data_as_2darray = }")
+
+# naturally, the 2darray version can be dumped to disk if you want:
+xr_data_as_2darray.to_netcdf("./xr_spotter_bulk_test_data_as_2darray.nc")
 
 # %%
 

--- a/examples/example_contiguous_ragged.py
+++ b/examples/example_contiguous_ragged.py
@@ -32,7 +32,7 @@ plt.show()
 # it is possible to get a 2d-array dataset version using trajan:
 
 # compare:
-print(f"{xr_data.traj.ds = }")
+print(f"{xr_data = }")
 
 # with:
 xr_data_as_2darray = xr_data.traj.to_2d()


### PR DESCRIPTION
I had not noticed that the last commit on the contiguous ragged PR (already merged) changed a bit of how and when things are called - the updated example now matches the changes of the last commits on the merged PR :) .