### PR TITLE
Making attribute names more precise: obsdim->obs_dimname, timedim->time_varname

### DIFF
--- a/examples/example_find_positions_at_obs_times.py
+++ b/examples/example_find_positions_at_obs_times.py
@@ -25,7 +25,7 @@ print(ds)
 def gridwaves(tds):
     t = tds[['lat', 'lon',
              'time']].traj.gridtime(tds['time_waves_imu'].squeeze())
-    return t.traj.to_2d(obsdim='obs_waves_imu')
+    return t.traj.to_2d(obs_dimname='obs_waves_imu')
 
 
 dsw = ds.groupby('trajectory').map(gridwaves)

--- a/examples/example_find_positions_at_obs_times.py
+++ b/examples/example_find_positions_at_obs_times.py
@@ -25,7 +25,7 @@ print(ds)
 def gridwaves(tds):
     t = tds[['lat', 'lon',
              'time']].traj.gridtime(tds['time_waves_imu'].squeeze())
-    return t.traj.to_2d(obs_dimname='obs_waves_imu')
+    return t.traj.to_2d(obs_dim='obs_waves_imu')
 
 
 dsw = ds.groupby('trajectory').map(gridwaves)

--- a/examples/example_opendrift.py
+++ b/examples/example_opendrift.py
@@ -21,7 +21,11 @@ with lzma.open('openoil.nc.xz') as oil:
     ds = ds.where(ds.status>=0)  # only active particles
 
 #%%
-# Displaying a basic plot of trajectories
+# Displaying some basic information about this dataset
+print(ds.traj)
+
+#%%
+# Making a basic plot of trajectories
 ds.traj.plot()
 plt.title('Basic trajectory plot')
 plt.show()

--- a/tests/test_read_sfy.py
+++ b/tests/test_read_sfy.py
@@ -8,7 +8,7 @@ def test_interpret_sfy(test_data):
     ds = xr.open_dataset(test_data / 'bug32.nc')
     print(ds)
 
-    assert ds.traj.obs_dimname == 'package'
+    assert ds.traj.obs_dim == 'package'
     assert ds.traj.time_varname == 'position_time'
 
     assert ds.traj.is_2d()

--- a/tests/test_read_sfy.py
+++ b/tests/test_read_sfy.py
@@ -8,8 +8,8 @@ def test_interpret_sfy(test_data):
     ds = xr.open_dataset(test_data / 'bug32.nc')
     print(ds)
 
-    assert ds.traj.obsdim == 'package'
-    assert ds.traj.timedim == 'position_time'
+    assert ds.traj.obs_dimname == 'package'
+    assert ds.traj.time_varname == 'position_time'
 
     assert ds.traj.is_2d()
 

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,0 +1,13 @@
+import xarray as xr
+import trajan as _
+
+def test_repr_1d(opendrift_sim):
+    repr = str(opendrift_sim.traj)
+    assert '2015-11-16T00:00' in repr
+    assert 'Timestep:       1:00:00' in repr
+    assert "67 timesteps    time['time'] (1D)" in repr
+
+def test_repr_2d(test_data):
+    ds = xr.open_dataset(test_data / 'bug32.nc')
+    repr = str(ds.traj)
+    assert '2023-10-19T15:46:53.514499520' in repr

--- a/trajan/accessor.py
+++ b/trajan/accessor.py
@@ -26,10 +26,10 @@ def detect_tx_dim(ds):
         raise ValueError("Could not determine x / lon variable")
 
 
-def detect_time_dim(ds, obsdim):
-    logger.debug(f'Detecting time-dimension for "{obsdim}"..')
+def detect_time_dim(ds, obs_dimname):
+    logger.debug(f'Detecting time-dimension for "{obs_dimname}"..')
     for v in ds.variables:
-        if obsdim in ds[v].dims and 'time' in v:
+        if obs_dimname in ds[v].dims and 'time' in v:
             return v
 
     raise ValueError("no time dimension detected")
@@ -47,8 +47,8 @@ class TrajA(Traj):
             ds = ds.expand_dims({'trajectory': 1})
             ds['trajectory'].attrs['cf_role'] = 'trajectory_id'
 
-        obsdim = None
-        timedim = None
+        obs_dimname = None
+        time_varname = None
 
         tx = detect_tx_dim(ds)
 
@@ -62,7 +62,7 @@ class TrajA(Traj):
             # NOTE: this is probably not standard; something to point to the CF conventions?
             # NOTE: for now, there is no discovery of the "index" dim, this is hardcorded; any way to do better?
             if "index" in tx.dims:
-                obsdim = "index"
+                obs_dimname = "index"
 
                 # discover the timecoord variable name #######################
                 # find all variables with standard_name "time"
@@ -90,14 +90,14 @@ class TrajA(Traj):
                 else:
                     raise ValueError(f"cannot deduce rowsizevar; we have the following candidates: {with_dim_trajectory = }")
                 # sanity check
-                if not np.sum(ds[rowsizevar].to_numpy()) == len(ds[obsdim]):
+                if not np.sum(ds[rowsizevar].to_numpy()) == len(ds[obs_dimname]):
                     raise ValueError("mismatch between the index length and the sum of the deduced trajectory lengths")
 
                 logger.debug(
-                    f"1D storage dataset; detected: {obsdim = }, {timecoord = }, {trajectorycoord = }, {rowsizevar}"
+                    f"1D storage dataset; detected: {obs_dimname = }, {timecoord = }, {trajectorycoord = }, {rowsizevar}"
                 )
 
-                return ocls(ds, obsdim, timecoord, trajectorycoord, rowsizevar)
+                return ocls(ds, obs_dimname, timecoord, trajectorycoord, rowsizevar)
 
             else:
                 logging.warning(f"{ds} has {tx.dims = } which is of dimension 1 but is not index; this is a bit unusual; try to parse with Traj1d or Traj2d")
@@ -105,16 +105,16 @@ class TrajA(Traj):
         # we have a ds where 2D arrays are used to store data, this is either Traj1d or Traj2d
         # there may also be some slightly unusual cases where these Traj1d and Traj2d classes will be used on data with 1D arrays
         if 'obs' in tx.dims:
-            obsdim = 'obs'
-            timedim = detect_time_dim(ds, obsdim)
+            obs_dimname = 'obs'
+            time_varname = detect_time_dim(ds, obs_dimname)
 
         elif 'index' in tx.dims:
-            obsdim = 'obs'
-            timedim = detect_time_dim(ds, obsdim)
+            obs_dimname = 'obs'
+            time_varname = detect_time_dim(ds, obs_dimname)
 
         elif 'time' in tx.dims:
-            obsdim = 'time'
-            timedim = 'time'
+            obs_dimname = 'time'
+            time_varname = 'time'
 
         else:
             for d in tx.dims:
@@ -122,31 +122,31 @@ class TrajA(Traj):
                         'cf_role',
                         None) == 'trajectory_id' and not 'traj' in d:
 
-                    obsdim = d
-                    timedim = detect_time_dim(ds, obsdim)
+                    obs_dimname = d
+                    time_varname = detect_time_dim(ds, obs_dimname)
 
                     break
 
-            if obsdim is None:
+            if obs_dimname is None:
                 logger.warning('No time or obs dimension detected.')
 
         logger.debug(
-            f"Detected obs-dim: {obsdim}, detected time-dim: {timedim}.")
+            f"Detected obs-dim: {obs_dimname}, detected time-dim: {time_varname}.")
 
-        if obsdim is None:
+        if obs_dimname is None:
             ocls = Traj1d
 
-        elif len(ds[timedim].shape) <= 1:
+        elif len(ds[time_varname].shape) <= 1:
             logger.debug('Detected structured (1D) trajectory dataset')
             ocls = Traj1d
 
-        elif len(ds[timedim].shape) == 2:
+        elif len(ds[time_varname].shape) == 2:
             logger.debug('Detected un-structured (2D) trajectory dataset')
             ocls = Traj2d
 
         else:
             raise ValueError(
-                f'Time dimension has shape greater than 2: {ds["timedim"].shape}'
+                f'Time dimension has shape greater than 2: {ds["time_varname"].shape}'
             )
 
-        return ocls(ds, obsdim, timedim)
+        return ocls(ds, obs_dimname, time_varname)

--- a/trajan/ragged.py
+++ b/trajan/ragged.py
@@ -14,12 +14,12 @@ class ContiguousRagged(Traj):
     trajdim: str
     rowvar: str
 
-    def __init__(self, ds, obs_dimname, time_varname, trajectorycoord, rowsizevar):
+    def __init__(self, ds, obs_dim, time_varname, trajectorycoord, rowsizevar):
         self.trajdim = trajectorycoord
         self.rowvar = rowsizevar
-        super().__init__(ds, obs_dimname, time_varname)
+        super().__init__(ds, obs_dim, time_varname)
 
-    def to_2d(self, obs_dimname='obs'):
+    def to_2d(self, obs_dim='obs'):
         """This actually converts a contiguous ragged xarray Dataset into an xarray Dataset that follows the Traj2d conventions."""
         global_attrs = self.ds.attrs
 
@@ -70,7 +70,7 @@ class ContiguousRagged(Traj):
 
             # trajectory vars
             'time':
-            xr.DataArray(dims=["trajectory", obs_dimname],
+            xr.DataArray(dims=["trajectory", obs_dim],
                          data=array_time,
                          attrs={
                              "standard_name": "time",
@@ -81,7 +81,7 @@ class ContiguousRagged(Traj):
 
         # now add all "normal" variables
         # NOTE: for now, we only consider scalar vars; if we want to consider more complex vars (e.g., spectra), this will need updated
-        # NOTE: such an update would typically need to look at the dims of the variable, and if there are additional dims to obs_dimname, create a higer dim variable
+        # NOTE: such an update would typically need to look at the dims of the variable, and if there are additional dims to obs_dim, create a higer dim variable
 
         for crrt_data_var in self.ds.data_vars:
             attrs = self.ds[crrt_data_var].attrs
@@ -90,9 +90,9 @@ class ContiguousRagged(Traj):
                 continue
 
             if len(self.ds[crrt_data_var].dims
-                   ) != 1 or self.ds[crrt_data_var].dims[0] != self.obs_dimname:
+                   ) != 1 or self.ds[crrt_data_var].dims[0] != self.obs_dim:
                 raise ValueError(
-                    f"data_vars element {crrt_data_var} has dims {self.ds[crrt_data_var].dims}, expected {(self.obs_dimname,)}"
+                    f"data_vars element {crrt_data_var} has dims {self.ds[crrt_data_var].dims}, expected {(self.obs_dim,)}"
                 )
 
             crrt_var = np.full((nbr_trajectories, longest_trajectory), np.nan)
@@ -119,7 +119,7 @@ class ContiguousRagged(Traj):
                 crrt_data_var = "lat"
 
             ds_converted_to_traj2d[crrt_data_var] = \
-                xr.DataArray(dims=["trajectory", obs_dimname],
+                xr.DataArray(dims=["trajectory", obs_dim],
                              data=crrt_var,
                              attrs=attrs)
 

--- a/trajan/ragged.py
+++ b/trajan/ragged.py
@@ -14,12 +14,12 @@ class ContiguousRagged(Traj):
     trajdim: str
     rowvar: str
 
-    def __init__(self, ds, obsdim, timedim, trajectorycoord, rowsizevar):
+    def __init__(self, ds, obs_dimname, time_varname, trajectorycoord, rowsizevar):
         self.trajdim = trajectorycoord
         self.rowvar = rowsizevar
-        super().__init__(ds, obsdim, timedim)
+        super().__init__(ds, obs_dimname, time_varname)
 
-    def to_2d(self, obsdim='obs'):
+    def to_2d(self, obs_dimname='obs'):
         """This actually converts a contiguous ragged xarray Dataset into an xarray Dataset that follows the Traj2d conventions."""
         global_attrs = self.ds.attrs
 
@@ -45,7 +45,7 @@ class ContiguousRagged(Traj):
                 self.ds[self.rowvar].to_numpy()):
             end_index = start_index + crrt_rowsize
             array_time[crrt_index, :crrt_rowsize] = self.ds[
-                self.timedim][start_index:end_index]
+                self.time_varname][start_index:end_index]
             start_index = end_index
 
         # it seems that we need to build the "backbone" of the Dataset independently first
@@ -70,7 +70,7 @@ class ContiguousRagged(Traj):
 
             # trajectory vars
             'time':
-            xr.DataArray(dims=["trajectory", obsdim],
+            xr.DataArray(dims=["trajectory", obs_dimname],
                          data=array_time,
                          attrs={
                              "standard_name": "time",
@@ -81,7 +81,7 @@ class ContiguousRagged(Traj):
 
         # now add all "normal" variables
         # NOTE: for now, we only consider scalar vars; if we want to consider more complex vars (e.g., spectra), this will need updated
-        # NOTE: such an update would typically need to look at the dims of the variable, and if there are additional dims to obsdim, create a higer dim variable
+        # NOTE: such an update would typically need to look at the dims of the variable, and if there are additional dims to obs_dimname, create a higer dim variable
 
         for crrt_data_var in self.ds.data_vars:
             attrs = self.ds[crrt_data_var].attrs
@@ -90,9 +90,9 @@ class ContiguousRagged(Traj):
                 continue
 
             if len(self.ds[crrt_data_var].dims
-                   ) != 1 or self.ds[crrt_data_var].dims[0] != self.obsdim:
+                   ) != 1 or self.ds[crrt_data_var].dims[0] != self.obs_dimname:
                 raise ValueError(
-                    f"data_vars element {crrt_data_var} has dims {self.ds[crrt_data_var].dims}, expected {(self.obsdim,)}"
+                    f"data_vars element {crrt_data_var} has dims {self.ds[crrt_data_var].dims}, expected {(self.obs_dimname,)}"
                 )
 
             crrt_var = np.full((nbr_trajectories, longest_trajectory), np.nan)
@@ -119,7 +119,7 @@ class ContiguousRagged(Traj):
                 crrt_data_var = "lat"
 
             ds_converted_to_traj2d[crrt_data_var] = \
-                xr.DataArray(dims=["trajectory", obsdim],
+                xr.DataArray(dims=["trajectory", obs_dimname],
                              data=crrt_var,
                              attrs=attrs)
 
@@ -140,6 +140,6 @@ class ContiguousRagged(Traj):
     def timestep(self, average=np.median):
         return self.to_2d().traj.timestep(average)
 
-    def gridtime(self, times, timedim=None, round=True):
-        return self.to_2d().traj.gridtime(times, timedim, round)
+    def gridtime(self, times, time_varname=None, round=True):
+        return self.to_2d().traj.gridtime(times, time_varname, round)
 

--- a/trajan/traj.py
+++ b/trajan/traj.py
@@ -20,7 +20,7 @@ from .animation import Animation
 logger = logging.getLogger(__name__)
 
 
-def detect_tx_dim(ds):
+def detect_tx_variable(ds):
     if 'lon' in ds:
         return ds.lon
     elif 'longitude' in ds:
@@ -31,15 +31,6 @@ def detect_tx_dim(ds):
         return ds.X
     else:
         raise ValueError("Could not determine x / lon variable")
-
-
-def detect_time_dim(ds, obs_dim):
-    logger.debug(f'Detecting time-dimension for "{obs_dim}"..')
-    for v in ds.variables:
-        if obs_dim in ds[v].dims and 'time' in v:
-            return v
-
-    raise ValueError("no time dimension detected")
 
 
 class Traj:
@@ -123,7 +114,7 @@ class Traj:
         tlon, ty
         """
 
-        return detect_tx_dim(self.ds)
+        return detect_tx_variable(self.ds)
 
     @property
     def ty(self):

--- a/trajan/traj.py
+++ b/trajan/traj.py
@@ -69,12 +69,12 @@ class Traj:
             end_time = self.ds.time.max().data
             output += f'Time coverage:  {start_time} - {end_time}\n'
         else:
-            output += f'Dataset has no time dimension'
+            output += f'Dataset has no time variable'
         output += f'Longitude span: {self.tx.min().data} to {self.tx.max().data}\n'
         output += f'Latitude span:  {self.ty.min().data} to {self.ty.max().data}\n'
         output += 'Variables:\n'
         for var in self.ds.variables:
-            if var not in ['trajectory', 'obs']:
+            if var not in ['trajectory', self.obs_dim]:
                 output += f'    {var}'
                 if 'standard_name' in self.ds[var].attrs:
                     output += f'  [{self.ds[var].standard_name}]'

--- a/trajan/traj1d.py
+++ b/trajan/traj1d.py
@@ -14,8 +14,8 @@ class Traj1d(Traj):
     A structured dataset, where each trajectory is always given at the same times. Typically the output from a model or from a gridded dataset.
     """
 
-    def __init__(self, ds, obs_dimname, time_varname):
-        super().__init__(ds, obs_dimname, time_varname)
+    def __init__(self, ds, obs_dim, time_varname):
+        super().__init__(ds, obs_dim, time_varname)
 
     def timestep(self):
         """Time step between observations in seconds."""
@@ -28,14 +28,14 @@ class Traj1d(Traj):
     def is_2d(self):
         return False
 
-    def to_2d(self, obs_dimname='obs'):
+    def to_2d(self, obs_dim='obs'):
         ds = self.ds.copy()
         time = ds[self.time_varname].rename({
-            self.time_varname: obs_dimname
+            self.time_varname: obs_dim
         }).expand_dims(dim={'trajectory': ds.sizes['trajectory']})
-        ds = ds.rename({self.time_varname: obs_dimname})
+        ds = ds.rename({self.time_varname: obs_dim})
         ds[self.time_varname] = time
-        ds[obs_dimname] = np.arange(0, ds.sizes[obs_dimname])
+        ds[obs_dim] = np.arange(0, ds.sizes[obs_dim])
 
         return ds
 
@@ -101,8 +101,8 @@ class Traj1d(Traj):
             )
 
         diff = np.max(
-            np.abs((self.ds[self.obs_dimname] -
-                    other[other.traj.obs_dimname]).astype('timedelta64[s]').astype(
+            np.abs((self.ds[self.obs_dim] -
+                    other[other.traj.obs_dim]).astype('timedelta64[s]').astype(
                         np.float64)))
 
         if not np.isclose(diff, 0):
@@ -112,11 +112,11 @@ class Traj1d(Traj):
 
         s = np.zeros((self.ds.sizes['trajectory']), dtype=np.float32)
 
-        # ds = self.ds.dropna(dim=self.obs_dimname)
-        # other = other.dropna(dim=other.traj.obs_dimname)
+        # ds = self.ds.dropna(dim=self.obs_dim)
+        # other = other.dropna(dim=other.traj.obs_dim)
 
-        ds = self.ds.transpose('trajectory', self.obs_dimname, ...)
-        other = other.transpose('trajectory', other.traj.obs_dimname, ...)
+        ds = self.ds.transpose('trajectory', self.obs_dim, ...)
+        other = other.transpose('trajectory', other.traj.obs_dim, ...)
 
         lon0 = ds.traj.tlon
         lat0 = ds.traj.tlat
@@ -165,9 +165,9 @@ class Traj1d(Traj):
 
         ds = self.ds
 
-        if self.obs_dimname != time_varname:
+        if self.obs_dim != time_varname:
             ds = ds.rename({
-                self.obs_dimname: time_varname
+                self.obs_dim: time_varname
             }).set_index({time_varname: time_varname})
 
         _, ui = np.unique(ds[time_varname], return_index=True)

--- a/trajan/traj1d.py
+++ b/trajan/traj1d.py
@@ -181,7 +181,7 @@ class Traj1d(Traj):
         if ds.sizes[time_varname] > 0:
             ds = ds.interp({time_varname: times})
         else:
-            logger.warning(f"time dimension ({time_varname}) is zero size")
+            logger.warning(f"time variable ({time_varname}) has zero size")
 
         if not 'trajectory' in ds.dims:
             ds = ds.expand_dims('trajectory')

--- a/trajan/traj2d.py
+++ b/trajan/traj2d.py
@@ -8,11 +8,11 @@ from .traj import Traj
 logger = logging.getLogger(__name__)
 
 
-def __require_obsdim__(f):
+def __require_obs_dimname__(f):
     """This decorator is for methods of Traj that require a time or obs dimension to work."""
 
     def wrapper(*args, **kwargs):
-        if args[0].obsdim is None:
+        if args[0].obs_dimname is None:
             raise ValueError(f'{f} requires an obs or time dimension')
         return f(*args, **kwargs)
 
@@ -24,8 +24,8 @@ class Traj2d(Traj):
     A unstructured dataset, where each trajectory may have observations at different times. Typically from a collection of drifters.
     """
 
-    def __init__(self, ds, obsdim, timedim):
-        super().__init__(ds, obsdim, timedim)
+    def __init__(self, ds, obs_dimname, time_varname):
+        super().__init__(ds, obs_dimname, time_varname)
 
     def timestep(self, average=np.nanmedian):
         """
@@ -132,30 +132,30 @@ class Traj2d(Traj):
 
         return xr.concat(trajs, dim='trajectory')
 
-    @__require_obsdim__
+    @__require_obs_dimname__
     def condense_obs(self) -> xr.Dataset:
 
-        on = self.ds.sizes[self.obsdim]
+        on = self.ds.sizes[self.obs_dimname]
         logger.debug(f'Condensing {on} observations.')
 
         ds = self.ds.copy(deep=True)
 
         # The observation coordinate will be re-written
-        ds = ds.drop_vars([self.obsdim])
+        ds = ds.drop_vars([self.obs_dimname])
 
-        assert self.obsdim in ds[
-            self.timedim].dims, "observation not a coordinate of time variable"
+        assert self.obs_dimname in ds[
+            self.time_varname].dims, "observation not a coordinate of time variable"
 
         # Move all observations for each trajectory to starting row
         maxN = 0
         for ti in range(len(ds.trajectory)):
             obsvars = [
-                var for var in ds.variables if self.obsdim in ds[var].dims
+                var for var in ds.variables if self.obs_dimname in ds[var].dims
             ]
             iv = np.full(on, False)
             for var in obsvars:
                 ivv = ~pd.isnull(
-                    ds[self.timedim][ti, :])  # valid times in this trajectory.
+                    ds[self.time_varname][ti, :])  # valid times in this trajectory.
                 iv = np.logical_or(iv, ivv)
 
             N = np.count_nonzero(iv)
@@ -178,46 +178,46 @@ class Traj2d(Traj):
                 # ), "Varying number of valid observations within same trajectory."
 
         logger.debug(f'Condensed observations from: {on} to {maxN}')
-        ds = ds.isel({self.obsdim: slice(0, maxN)})
+        ds = ds.isel({self.obs_dimname: slice(0, maxN)})
 
         # Write new observation coordinate.
         obs = np.arange(0, maxN)
-        ds = ds.assign_coords({self.obsdim: obs})
+        ds = ds.assign_coords({self.obs_dimname: obs})
 
         return ds
 
-    @__require_obsdim__
+    @__require_obs_dimname__
     def seltime(self, t0=None, t1=None):
         if t0 is None:
-            t0 = np.nanmin(self.ds[self.timedim].values.ravel())
+            t0 = np.nanmin(self.ds[self.time_varname].values.ravel())
         if t1 is None:
-            t1 = np.nanmax(self.ds[self.timedim].values.ravel())
+            t1 = np.nanmax(self.ds[self.time_varname].values.ravel())
 
         t0 = pd.to_datetime(t0)
         t1 = pd.to_datetime(t1)
 
-        return self.ds.where(np.logical_and(self.ds[self.timedim] >= t0,
-                                            self.ds[self.timedim] <= t1),
+        return self.ds.where(np.logical_and(self.ds[self.time_varname] >= t0,
+                                            self.ds[self.time_varname] <= t1),
                              drop=True)
 
-    @__require_obsdim__
+    @__require_obs_dimname__
     def iseltime(self, i):
 
         def select(t):
-            ii = np.argwhere(~pd.isna(t[self.timedim]).squeeze())
+            ii = np.argwhere(~pd.isna(t[self.time_varname]).squeeze())
             ii = ii[i].squeeze()
 
-            o = t.isel({self.obsdim: ii})
+            o = t.isel({self.obs_dimname: ii})
 
-            if self.obsdim in o.dims:
+            if self.obs_dimname in o.dims:
                 return o
             else:
-                return o.expand_dims(self.obsdim)
+                return o.expand_dims(self.obs_dimname)
 
         return self.ds.groupby('trajectory').map(select)
 
-    @__require_obsdim__
-    def gridtime(self, times, timedim=None, round=True):
+    @__require_obs_dimname__
+    def gridtime(self, times, time_varname=None, round=True):
         if isinstance(times, str) or isinstance(
                 times, pd.Timedelta):  # Make time series with given interval
             if round is True:
@@ -235,27 +235,27 @@ class Traj2d(Traj):
         if not isinstance(times, np.ndarray):
             times = times.to_numpy()
 
-        timedim = self.timedim if timedim is None else timedim
+        time_varname = self.time_varname if time_varname is None else time_varname
 
         d = None
 
         for t in range(self.ds.sizes['trajectory']):
             dt = self.ds.isel(trajectory=t) \
-                        .dropna(self.obsdim, how='all')
+                        .dropna(self.obs_dimname, how='all')
 
-            dt = dt.assign_coords({self.obsdim : dt[self.timedim].values }) \
-                   .drop_vars(self.timedim) \
-                   .rename({self.obsdim : timedim}) \
-                   .set_index({timedim: timedim})
+            dt = dt.assign_coords({self.obs_dimname : dt[self.time_varname].values }) \
+                   .drop_vars(self.time_varname) \
+                   .rename({self.obs_dimname : time_varname}) \
+                   .set_index({time_varname: time_varname})
 
-            _, ui = np.unique(dt[timedim], return_index=True)
-            dt = dt.isel({timedim: ui})
-            dt = dt.isel({timedim: np.where(~pd.isna(dt[timedim].values))[0]})
+            _, ui = np.unique(dt[time_varname], return_index=True)
+            dt = dt.isel({time_varname: ui})
+            dt = dt.isel({time_varname: np.where(~pd.isna(dt[time_varname].values))[0]})
 
-            if dt.sizes[timedim] > 0:
-                dt = dt.interp({timedim: times})
+            if dt.sizes[time_varname] > 0:
+                dt = dt.interp({time_varname: times})
             else:
-                logger.warning(f"time dimension ({timedim}) is zero size")
+                logger.warning(f"time dimension ({time_varname}) is zero size")
 
             if d is None:
                 d = dt.expand_dims('trajectory')


### PR DESCRIPTION
So far mainly a mechanical search & replace
Thus some comments are still inconsistent, e.g. refering to `time_varname` as time dimension.

Also remains to add an attribute `trajectory_dimname`, but can perhaps be made in a subsequent pull request. So far this is hardcoded as "trajectory" at some places.