### PR TITLE
Add example of compression, chunking by trajectory

### DIFF
--- a/examples/example_compress.py
+++ b/examples/example_compress.py
@@ -1,0 +1,64 @@
+"""
+Examples of compressing data when dumping to .nc
+==============================================================================
+"""
+
+# %%
+
+import xarray as xr
+from trajan.readers.omb import read_omb_csv
+from pathlib import Path
+
+# %%
+
+path_to_test_data = Path.cwd().parent / "tests" / "test_data" / "csv" / "omb_large.csv"
+xr_buoys = read_omb_csv(path_to_test_data)
+
+# %%
+
+# by default, to_netcdf does not perform any compression
+xr_buoys.to_netcdf("no_compression.nc")
+
+# on my machine, this is around 33MB
+!ls -lh no_compression.nc
+
+# %%
+
+# one can perform compression by providing explicitly the right arguments
+# note that the best way to compress may depend on your dataset, the access
+# pattern you want to be fastest, etc - be aware of memory layout and
+# performance!
+
+# a simple compression, on a per-trajectory basis: each trajectory will
+# be compressed as a chunk, this means that it will be fast to retrieve one
+# full trajectory, but slow to retrieve e.g. the 5th point of all trajectories.
+
+# choose the encoding chunking - this may be application dependent, here
+# chunk trajectory as a whole
+def generate_chunksize(var):
+    dims = xr_buoys[var].dims
+    shape = list(xr_buoys[var].shape)
+
+    idx_trajectory = dims.index("trajectory")
+    shape[idx_trajectory] = 1
+
+    return tuple(shape)
+    
+
+# set the encoding for each variable
+encoding = {
+    var: {"zlib": True, "complevel": 5, "chunksizes": generate_chunksize(var)} \
+        for var in xr_buoys.data_vars
+}
+
+# the encoding looks like:
+for var in encoding:
+    print(f"{var}: {encoding[var] = }")
+
+# dump, this time with compression
+xr_buoys.to_netcdf("trajectory_compression.nc", encoding=encoding)
+
+# on my machine, this is around 5.6MB
+!ls -lh trajectory_compression.nc
+
+# %%

--- a/examples/example_compress.py
+++ b/examples/example_compress.py
@@ -8,6 +8,7 @@ Examples of compressing data when dumping to .nc
 import xarray as xr
 from trajan.readers.omb import read_omb_csv
 from pathlib import Path
+import os
 
 # %%
 
@@ -20,7 +21,7 @@ xr_buoys = read_omb_csv(path_to_test_data)
 xr_buoys.to_netcdf("no_compression.nc")
 
 # on my machine, this is around 33MB
-print("ls -lh no_compression.nc\n-rw-rw-r-- 1 jeanr jeanr 33M nov.  28 14:59 no_compression.nc")
+print(f"size no compression: {round(os.stat('no_compression.nc').st_size/(pow(1024,2)), 2)} MB")
 
 # %%
 
@@ -54,11 +55,12 @@ encoding = {
 # the encoding looks like:
 for var in encoding:
     print(f"{var}: {encoding[var] = }")
+print("")
 
 # dump, this time with compression
 xr_buoys.to_netcdf("trajectory_compression.nc", encoding=encoding)
 
 # on my machine, this is around 5.6MB
-print("!ls -lh trajectory_compression.nc\n-rw-rw-r-- 1 jeanr jeanr 5,6M nov.  28 15:01 trajectory_compression.n")
+print(f"size with compression: {round(os.stat('trajectory_compression.nc').st_size/(pow(1024,2)), 2)} MB")
 
 # %%

--- a/examples/example_compress.py
+++ b/examples/example_compress.py
@@ -1,5 +1,5 @@
 """
-Examples of compressing data when dumping to .nc
+Examples of compressing data when saving to .nc
 ==============================================================================
 """
 
@@ -57,7 +57,7 @@ for var in encoding:
     print(f"{var}: {encoding[var] = }")
 print("")
 
-# dump, this time with compression
+# save, this time with compression
 xr_buoys.to_netcdf("trajectory_compression.nc", encoding=encoding)
 
 # on my machine, this is around 5.6MB

--- a/examples/example_compress.py
+++ b/examples/example_compress.py
@@ -20,7 +20,7 @@ xr_buoys = read_omb_csv(path_to_test_data)
 xr_buoys.to_netcdf("no_compression.nc")
 
 # on my machine, this is around 33MB
-!ls -lh no_compression.nc
+print("ls -lh no_compression.nc\n-rw-rw-r-- 1 jeanr jeanr 33M nov.  28 14:59 no_compression.nc")
 
 # %%
 
@@ -59,6 +59,6 @@ for var in encoding:
 xr_buoys.to_netcdf("trajectory_compression.nc", encoding=encoding)
 
 # on my machine, this is around 5.6MB
-!ls -lh trajectory_compression.nc
+print("!ls -lh trajectory_compression.nc\n-rw-rw-r-- 1 jeanr jeanr 5,6M nov.  28 15:01 trajectory_compression.n")
 
 # %%


### PR DESCRIPTION
This is to illustrate how the user can compress the data.

This is a bit verbose, but given that the users may want to chunk in another way, this is what I think could be most pedagogical.

I added a larger file to the `test_data`, so that compression actually helps (with the small files we had so far, compression was degrading size, which is understandable :) ).

closes #144 