### PR TITLE
Fixed error in traj2d.time_to_next() due to indices shifting after ma…

### DIFF
--- a/trajan/traj2d.py
+++ b/trajan/traj2d.py
@@ -62,8 +62,8 @@ class Traj2d(Traj):
         time = self.ds.time
         lenobs = self.ds.sizes[self.obs_dim]
         td = time.diff(dim=self.obs_dim)
-        td.coords[self.obs_dim] = time[self.obs_dim]  # Same time index as initial
         td = xr.concat((td, td.isel(obs=-1)), dim=self.obs_dim)  # Repeat last time step
+        td.coords[self.obs_dim] = time[self.obs_dim]  # Same time index as initial
         return td.astype("timedelta64[s]").rename("time_to_next").assign_attrs({"units": "seconds"})
 
     def is_1d(self):


### PR DESCRIPTION
…nipulation. Must remember that Xarray DataArrays are not NumPy Arrays.