### PR TITLE
fix: encode time vars with float64 and clean epoch for xarray >= 2025 compat

### DIFF
--- a/tests/test_read_omb_csv.py
+++ b/tests/test_read_omb_csv.py
@@ -20,7 +20,7 @@ def test_read_csv_omb_default_waves(test_data, tmpdir):
 
     ds.to_netcdf(tmpdir / 'test.nc')
 
-    ds2 = xr.open_dataset(tmpdir / 'test.nc')
+    ds2 = xr.open_dataset(tmpdir / 'test.nc', decode_cf=True)
     assert ds2.attrs['time_coverage_start'] == '2022-11-12T00:00:37'
     assert ds2.attrs['time_coverage_end'] == '2022-11-12T02:30:27'
 

--- a/trajan/readers/omb.py
+++ b/trajan/readers/omb.py
@@ -488,4 +488,15 @@ def read_omb_csv(path_in: Path|pd.DataFrame,
         "created with trajan.reader.omb from a Rock7 Iridium CSV file of OMB transmissions"
     )
 
+    # Ensure time variables are encoded with a clean epoch and float dtype so
+    # xarray's numpy-based decoder (xarray >= 2025) can round-trip through
+    # netCDF. Using float64 avoids int64 overflow when NaT fill values are
+    # decoded as large integer offsets.
+    for tvar in ("time", "time_waves_imu"):
+        if tvar in xr_result:
+            xr_result[tvar].encoding.update({
+                "units": "seconds since 1970-01-01",
+                "dtype": "float64",
+            })
+
     return xr_result


### PR DESCRIPTION
xarray 2025.9.0 switched to a numpy-based time decoder that fails in two ways:
- rejects reference times with non-zero seconds (e.g. 'seconds since 2022-11-12 00:00:37')
- overflows when decoding NaT (int64.min) stored as integer seconds

Fix by explicitly encoding time and time_waves_imu with
'seconds since 1970-01-01' and dtype=float64 so NaT round-trips as NaN.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
