### PR TITLE
Gallery figure coverage still wrong, trying to add two more sphinx ga…

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,6 +41,8 @@ sphinx_gallery_conf = {
      'thumbnail_size': (300, 300),
      'junit': '../../test-results/sphinx-gallery/junit.xml',
      'reset_modules': ('matplotlib'),
+     'matplotlib_animations': True,
+     'savefig_kwargs': {'bbox_inches': 'tight'},
 }
 
 extensions = [


### PR DESCRIPTION
…llery options: matplotlib_animations->True and savefig_kwargs->bbox_inches: tight