### PR TITLE
For plots with geographic CRS, revert to PlateCarree() with axis orde…

### DIFF
--- a/trajan/plot/__init__.py
+++ b/trajan/plot/__init__.py
@@ -166,8 +166,9 @@ class Plot:
         #       using self.ds.traj.tlon/tlat
         x = self.ds.traj.tx.values.T
         y = self.ds.traj.ty.values.T
-        #dcrs = self.ds.traj.ccrs
-        dcrs = self.gcrs
+        dcrs = self.ds.traj.ccrs
+        if dcrs is not None and dcrs.is_geographic:
+            dcrs = self.gcrs  # avoid axis order issue with EPSG:4326
 
         cartesian = self.__cartesian__
 


### PR DESCRIPTION
…r (x, y) which is different from (lat, lon) of EPSG4326